### PR TITLE
טעות בעץ?

### DIFF
--- a/lisp.tex
+++ b/lisp.tex
@@ -672,8 +672,9 @@ expression| (ביטוי סימבולי). המילה "סימבולי" מטעימ�
   }
   \begin{forest}
     x tree [a,
-        [a,[car,[x]]]
-          [+, [b] [x]]
+        [b]
+        [car,[x]]
+        [+b, [x]]
       ]
   \end{forest}
 \end{LTR}


### PR DESCRIPTION
The original tree expression:  (a b (car x) (+b x))
The build expression: [a,
        [a,[car,[x]]]
          [+, [b] [x]]
]

I believe there are 3 mistakes:
1. In the original expression the letter b shows up twice but in the actual build expression it shows up once (this could be either a typo in the original expression or in the build expression)
2. In the build expression there are only two sons for the first node ('a') but based on the expression I think there should be 3 (b, car, +b)
3. I think +b is one s-expression and not 2 like "+ b" (or maybe you meant to put a space so there are 2 s-expressions)

*I don't know what was your original meaning for the tree so you can either change the expression or the build expression of the tree.

*I changed the build expression to fit the original expression (which is (a b (car x) (+b x)) ) but I'm not sure if I changed it correctly because I'm not sure what is the syntax used for expressing trees.