### PR TITLE
Update lisp.tex - FIX APPLY-DECOMPOSED-LAMBDA

### DIFF
--- a/lisp.tex
+++ b/lisp.tex
@@ -2057,9 +2057,10 @@ apply אשר מפעילה את ביטוי ה-$λ$ על הפרמטרים.
 \begin{KERNEL}
 (defun apply-decompsed-lambda(tag formals body actuals a-list)
   (evaluate body
-    (cond (eq tag 'nlambda) (bind formals actuals a-list)
-          (eq tag 'lambda) (bind formals (evaluate-list actuals a-list) a-list)
-          (t (error 'unkown-lambda tag)))))
+    (cond ((eq tag 'nlambda) (bind formals actuals a-list))
+          ((eq tag 'lambda) (bind formals (evaluate-list actuals a-list) a-list))
+          (t (error 'unkown-lambda tag))
+)))
 \end{KERNEL}
 
 האבחנה בין הסוגים השונים של ביטוי ה-$λ$, נעשית באופן הבא בפונקציה


### PR DESCRIPTION
Missing parentheses for cond testforms