### PR TITLE
[issue-361] - Fix compilation failed in the latest version

### DIFF
--- a/Mini-LISP/Makefile
+++ b/Mini-LISP/Makefile
@@ -1,4 +1,5 @@
 OBJS = mini-lisp.o dump.o strings.o pairs.o stack-trace.o main.o tokenizer.o parser.o stack.o io.o
+TEST_OBJS = test-main.o test.o tokenizer-test.o ast-test.o strings-test.o pairs-test.o parser-test.o stack-test.o stack-trace.o dump.o io.o
 SRCS = $(wildcard *.c) $(wildcard *.cc) 
 
 ifndef BUILD_MODE
@@ -16,7 +17,7 @@ else
     $(error Build mode $(BUILD_MODE) not supported by this Makefile)
 endif
 
-CFLAGS += -MD -MP 
+CFLAGS += -MD -MP -w
 
 all: mini-lisp test
 
@@ -26,7 +27,7 @@ dump.cc: dump.h
 
 parser-test.cc: parser.cc
 
-tokenzier-test.cc: tokenizer.cc
+tokenizer-test.cc: tokenizer.cc
 
 %.o: %.cc
 	$(CXX) $(CFLAGS) $(CPPFLAGS) -c $<
@@ -37,7 +38,7 @@ tokenzier-test.cc: tokenizer.cc
 mini-lisp:	$(OBJS) 
 	$(CXX) $(LDFLAGS) -o $@ $^ 
 
-test: test-main.o test.o tokenizer-test.o ast-test.o strings-test.o pairs-test.o parser-test.o stack-test.o stack-trace.o dump.o io.o
+test: $(TEST_OBJS)
 	$(CXX) $(LDFLAGS) -o $@ $^ -lgtest -lpthread
 
 # -include $(SRC:%.c=%.d)

--- a/Mini-LISP/main.cc
+++ b/Mini-LISP/main.cc
@@ -48,7 +48,7 @@ static S REPL() {
   Read:
     if (getline(&line, &n, stdin) < 0) 
       throw;
-    supply(line);
+    supply((char*)line);
     switch (status()) {
       case ready:
         prompt("- ");

--- a/Mini-LISP/mini-lisp.h
+++ b/Mini-LISP/mini-lisp.h
@@ -1,4 +1,5 @@
 #include <cstdint>
+#include <iostream>
 #ifndef MINI_LISP_H
 #define MINI_LISP_H 
 
@@ -76,6 +77,9 @@ extern S list(S);
 extern S list(S, S);
 extern S list(S, S, S );
 extern S list(S, S, S, S);
+
+static void error(String s) {  std::cerr << s;  throw __LINE__; }
+static void error(String s, S s1) {  std::cerr << s << " " << s1.asAtom();  throw __LINE__; }
 
 #undef construct
 #endif // MINI_LISP_H 

--- a/Mini-LISP/parser.h
+++ b/Mini-LISP/parser.h
@@ -19,7 +19,7 @@ namespace Parser {
   extern S result(); // Result of parrsing action; undefined if status is not accept 
   enum Status { ready, accept, reject}; // Should still work on resuming after NL 
   extern enum Status status();
-  extern void supply(const char *input); // What to parse, ideally in installments
+  extern void supply(char *input); // What to parse, ideally in installments
   extern void reset(); // Must call before the first supply
 
   /* Used in the LL(1) parsing algorithm; integer range tricks

--- a/Mini-LISP/strings.cc
+++ b/Mini-LISP/strings.cc
@@ -7,15 +7,15 @@
 #endif
 // Planned global data layout.
 static const bool active = true; 
-static struct { // Falls in the data segment; should be just before Pairs::buffer
-   // This is where strings go, negative handles.
-   char pool1[active<<10] = "BOTTOM";
-   // handle 0 should be exactly here.
-   char nil[sizeof("NIL")] = "NIL";
-   // positive (i.e., not - handles point here. be careful 2^15 is not a positive number 
-   Pair pool2[(active << 15)-2]; // not sure about the 2 here; add test
-} data;
-  
+//static struct { // Falls in the data segment; should be just before Pairs::buffer
+//   // This is where strings go, negative handles.
+//   char pool1[active<<10] = "BOTTOM";
+//   // handle 0 should be exactly here.
+//   char nil[sizeof("NIL")] = "NIL";
+//   // positive (i.e., not - handles point here. be careful 2^15 is not a positive number
+//   Pair pool2[(active << 15)-2]; // not sure about the 2 here; add test
+//} data;
+
 namespace Strings { // Atoms are never freed in mini-lisp
   define(M = 1024); // We use a total of M + sizeof("NIL") (typically 4) bytes
   static struct { // Falls in the data segment; should be just before Pairs::buffer

--- a/Mini-LISP/test.h
+++ b/Mini-LISP/test.h
@@ -2,5 +2,3 @@
 inline auto operator == (const S s1,const S s2) { return s1.index == s2.index; }
 inline auto operator != (const S s1,const S s2) { return s1.index != s2.index; }
 inline auto operator !(const S s) { return s.null(); }
-static void error(String s) {  std::cerr << s;  throw __LINE__; }
-static void error(String s, S s1) {  std::cerr << s << s1;  throw __LINE__; }


### PR DESCRIPTION
Fix compilation for both tests and mini-lisp executable.
Add -w in the Makefile to ignore the annoying + add TEST_OBJS variable.

